### PR TITLE
Remove "-p" option from add-replica call

### DIFF
--- a/add-repository
+++ b/add-repository
@@ -53,7 +53,7 @@ if $CREATEREPO; then
         mv /srv/cvmfs/$REPONAME /srv/cvmfs/.$REPONAME.save
     fi
     RET=0
-    if ! cvmfs_server add-replica -p -o root $REPOURL $PUBKEY$EXTRAPUBKEY; then
+    if ! cvmfs_server add-replica -o root $REPOURL $PUBKEY$EXTRAPUBKEY; then
         RET=1
     fi
     if [ -d /srv/cvmfs/.$REPONAME.save ]; then


### PR DESCRIPTION
In the add-repository script, "-p" is used to disable the creation of an apache config. There is no longer any need to accomodate old client configs, so repos should be created with the per-repo httpd config.